### PR TITLE
Fix case with Infinity. `exp` value in decode always must be zero, ot…

### DIFF
--- a/v2/number.go
+++ b/v2/number.go
@@ -180,6 +180,7 @@ func (num *Number) decode() (strNum string, exp int, negative bool, err error) {
 
 	if _isPosInf(num.data) || _isNegInf(num.data) {
 		strNum = "Infinity"
+		exp = 0
 		return
 	}
 


### PR DESCRIPTION
…herwise String method adds extra trailing zeroes to the string.